### PR TITLE
Background Delivery of health data through SpeziHealthKit beta

### DIFF
--- a/NeutroFeverGuard.xcodeproj/project.pbxproj
+++ b/NeutroFeverGuard.xcodeproj/project.pbxproj
@@ -1234,7 +1234,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.0-beta.3";
+				version = "1.0.0-beta.1";
 			};
 		};
 		2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */ = {

--- a/NeutroFeverGuard.xcodeproj/project.pbxproj
+++ b/NeutroFeverGuard.xcodeproj/project.pbxproj
@@ -77,8 +77,6 @@
 		C49EC8532D5038AC005C3495 /* DataInputForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49EC8522D5038AC005C3495 /* DataInputForm.swift */; };
 		C4A367C82D73C1EC009923C9 /* DataErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A367C72D73C1E1009923C9 /* DataErrorTests.swift */; };
 		C4C0A78F2D518DBC00F37EEC /* HelperFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C0A78E2D518DB500F37EEC /* HelperFunc.swift */; };
-		C4C8A3542D6F94C800F313AE /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = F2A54D362D5DE24400A20113 /* FirebaseCore */; };
-		C4C8A3552D6F94C800F313AE /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = F2A54D382D5DE24E00A20113 /* FirebaseFirestore */; };
 		C4C8A35F2D6F950600F313AE /* AddDataViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C8A35E2D6F950600F313AE /* AddDataViewTests.swift */; };
 		C4C8A3682D6F9E2100F313AE /* LabViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C8A3672D6F9E1A00F313AE /* LabViewUITests.swift */; };
 		C4C8A3B32D71204200F313AE /* HelperFuncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C8A3B22D71204200F313AE /* HelperFuncTests.swift */; };
@@ -1235,8 +1233,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.6.0;
+				kind = exactVersion;
+				version = "1.0.0-beta.3";
 			};
 		};
 		2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */ = {

--- a/NeutroFeverGuard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NeutroFeverGuard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
       "state" : {
-        "revision" : "fbdec78fcb2f90d6338f1968e21dd11fbee65070",
-        "version" : "0.6.0"
+        "revision" : "90575b75be77aa3f7bcf59dd6aa86551a72fe281",
+        "version" : "1.0.0-beta.1"
       }
     },
     {

--- a/NeutroFeverGuard/NeutroFeverGuardDelegate.swift
+++ b/NeutroFeverGuard/NeutroFeverGuardDelegate.swift
@@ -102,8 +102,8 @@ class NeutroFeverGuardDelegate: SpeziAppDelegate {
     private var healthKit: HealthKit {
         HealthKit {
             CollectSample(HKQuantityType(.heartRate), predicate: predicateOneMonth, deliverySetting: .background(.automatic))
-            CollectSample(HKQuantityType(.oxygenSaturation), predicate: predicateOneMonth,deliverySetting: .background(.automatic))
-            CollectSample(HKQuantityType(.bodyTemperature), predicate: predicateOneMonth,deliverySetting: .background(.automatic))
+            CollectSample(HKQuantityType(.oxygenSaturation), predicate: predicateOneMonth, deliverySetting: .background(.automatic))
+            CollectSample(HKQuantityType(.bodyTemperature), predicate: predicateOneMonth, deliverySetting: .background(.automatic))
         }
     }
 }

--- a/NeutroFeverGuard/NeutroFeverGuardDelegate.swift
+++ b/NeutroFeverGuard/NeutroFeverGuardDelegate.swift
@@ -101,10 +101,9 @@ class NeutroFeverGuardDelegate: SpeziAppDelegate {
     
     private var healthKit: HealthKit {
         HealthKit {
-            CollectSample(HKQuantityType(.heartRate), predicate: predicateOneMonth, deliverySetting: .anchorQuery(.automatic))
-            CollectSample(HKQuantityType(.oxygenSaturation), predicate: predicateOneMonth, deliverySetting: .anchorQuery(.automatic))
-            CollectSample(HKQuantityType(.appleSleepingWristTemperature), predicate: predicateOneMonth, deliverySetting: .anchorQuery(.automatic))
-            CollectSample(HKQuantityType(.bodyTemperature), predicate: predicateOneMonth, deliverySetting: .anchorQuery(.automatic))
+            CollectSample(HKQuantityType(.heartRate), predicate: predicateOneMonth, deliverySetting: .background(.automatic))
+            CollectSample(HKQuantityType(.oxygenSaturation), predicate: predicateOneMonth,deliverySetting: .background(.automatic))
+            CollectSample(HKQuantityType(.bodyTemperature), predicate: predicateOneMonth,deliverySetting: .background(.automatic))
         }
     }
 }

--- a/NeutroFeverGuard/NeutroFeverGuardDelegate.swift
+++ b/NeutroFeverGuard/NeutroFeverGuardDelegate.swift
@@ -101,9 +101,9 @@ class NeutroFeverGuardDelegate: SpeziAppDelegate {
     
     private var healthKit: HealthKit {
         HealthKit {
-            CollectSample(HKQuantityType(.heartRate), predicate: predicateOneMonth, deliverySetting: .background(.automatic))
-            CollectSample(HKQuantityType(.oxygenSaturation), predicate: predicateOneMonth, deliverySetting: .background(.automatic))
-            CollectSample(HKQuantityType(.bodyTemperature), predicate: predicateOneMonth, deliverySetting: .background(.automatic))
+            CollectSample(.heartRate, continueInBackground: true, predicate: predicateOneMonth)
+            CollectSample(.bloodOxygen, continueInBackground: true, predicate: predicateOneMonth)
+            CollectSample(.bodyTemperature, continueInBackground: true, predicate: predicateOneMonth)
         }
     }
 }

--- a/NeutroFeverGuard/Onboarding/OnboardingFlow.swift
+++ b/NeutroFeverGuard/Onboarding/OnboardingFlow.swift
@@ -33,7 +33,9 @@ struct OnboardingFlow: View {
             return false
         }
         
-        return healthKitDataSource.authorized
+        return healthKitDataSource.isAuthorized(toWrite: HKQuantityType(.heartRate)) &&
+        healthKitDataSource.isAuthorized(toWrite: HKQuantityType(.oxygenSaturation)) &&
+        healthKitDataSource.isAuthorized(toWrite: HKQuantityType(.bodyTemperature))
     }
     
     

--- a/NeutroFeverGuard/Supporting Files/Info.plist
+++ b/NeutroFeverGuard/Supporting Files/Info.plist
@@ -19,6 +19,7 @@
 	<array>
 		<string>fetch</string>
 		<string>audio</string>
+		<string>processing</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
# *Background Delivery of health data*

## :recycle: Current situation & Problem
* the health data was not continuously pushed in the background.
* the dependencies are updated and conflicts are resolved.

## :gear: Release Notes 
* As Paul suggested, Now using spezihealthkit's beta release, we can fetch and push healthkit data in the background continuously. I changed the code and submitting a small PR to keep things clean.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
