### PR TITLE
Update documentation

### DIFF
--- a/Notification.md
+++ b/Notification.md
@@ -1,0 +1,54 @@
+# Background Checking & Lab Notification - NeutroFeverGuard
+This file explains how background checking and lab results reminders work in NeutroFeverGuard.
+
+Back to [README](README.md).
+
+## Background Checking
+
+## Lab Notification
+
+NeutroFeverGuard helps chemotherapy patients track lab results by sending daily reminders at **9:00 AM** if no data has been recorded for over 7 days. This is handled through the [SpeziScheduler](https://github.com/StanfordSpezi/SpeziScheduler) module.  
+
+Whenever a user records new lab results, the app automatically marks the next **7 days' events as complete** to avoid unnecessary reminders.  
+
+Example:  
+- Result recorded on March 1 → Events from March 1 to March 7 marked complete  
+- Next reminder on March 8 if no new result is added
+
+When a lab result is deleted, the app checks whether the deleted result corresponds to the **most recent completed event**:  
+
+1. If not the latest result → No action needed, future notifications continue as scheduled.  
+2. If it’s the latest result → Restart the notification schedule to re-enable reminders, because there’s no direct "unmark as complete" method in `SpeziScheduler`.
+
+If a recent lab result is deleted, we reset the schedule with this logic:
+
+```swift
+@MainActor
+func restartNotification(from date: Date) {
+    do {
+        // Delete all existing task versions and their outcomes
+        try scheduler.deleteAllVersions(ofTask: "enter-lab-result")
+    } catch {
+        print("Failed to delete previous task versions")
+    }
+    
+    do {
+        // Create a fresh task starting from the given date
+        try scheduler.createOrUpdateTask(
+            id: "enter-lab-result",
+            title: "Enter Lab Results",
+            instructions: "You haven't recorded your lab results for last 7 days. Record now!",
+            category: .measurement,
+            schedule: .daily(hour: 9, minute: 0, startingAt: date),
+            scheduleNotifications: true,
+            shadowedOutcomesHandling: .delete
+        )
+    } catch {
+        viewState = .error(AnyLocalizedError(error: error, defaultErrorDescription: "Failed to create or update scheduled tasks."))
+    }
+}
+```
+> [!NOTE]  
+> **Why Delete Before Create?** When restarting the "enter-lab-result" task schedule, previously completed events remained marked as complete, even after calling `createOrUpdateTask` with `shadowedOutcomesHandling: .delete`. This happened because `createOrUpdateTask` updates the task definition but doesn’t automatically clear old outcomes that still match the new schedule.
+
+Now you know how background checking & lab notification work in NeutroFeverGuard! Welcome back to [README](README.md).

--- a/README.md
+++ b/README.md
@@ -19,16 +19,63 @@ This repository contains the NeutroFeverGuard application.
 NeutroFeverGuard is using the [Spezi](https://github.com/StanfordSpezi/Spezi) ecosystem and builds on top of the [Stanford Spezi Template Application](https://github.com/StanfordSpezi/SpeziTemplateApplication).
 
 > [!TIP]
-> Do you want to test the NeutroFeverGuard application on your device? [You can downloard it on TestFlight](https://testflight.apple.com/join/CAuYHs84).
+> Do you want to test the NeutroFeverGuard application on your device? [You can download it on TestFlight](https://testflight.apple.com/join/CAuYHs84).
 
+## Overview
+**NeutroFeverGuard** is designed to monitor symptoms of chemotherapy patients and enable early detection of febrile neutropenia. The app empowers users to:  
+1. Record and track vitals, lab values, medications, and symptoms.  
+2. Sync data with the Apple Health app and view interactive visualizations of health trends.  
+3. Receive reminders for uploading lab results and notifications in case of febrile neutropenia risk.
 
-## NeutroFeverGuard Features
+## Features
 
-*Provide a comprehensive description of your application, including figures showing the application. You can learn more on how to structure a README in the [Stanford Spezi Documentation Guide](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/documentation-guide)*
+Screenshots table:
+
+1. Visualization page
+2. Add data page
+3. Lab page
+4. Medication page
+5. Contact page (?)
+6. On boarding page / schedule 
+
+### I. Health Record Tracking
+
+#### Health Data Sources:
+1. **Apple Health App**: Data recorded by Apple Watch or other Bluetooth-enabled sensors via HealthKit.  
+2. **Manual Entry**: Users can manually add health data, including vital signs and lab values.
 
 > [!NOTE]  
-> Do you want to learn more about the Stanford Spezi Template Application and how to use, extend, and modify this application? Check out the [Stanford Spezi Template Application documentation](https://stanfordspezi.github.io/SpeziTemplateApplication)
+> How is the data being processed and stored? NeutroFeverGuard use [Spezi Local Storage](https://github.com/StanfordSpezi/SpeziStorage) to store lab results and medication data locally. Other health data is stored in [Healthkit](https://github.com/StanfordSpezi/SpeziHealthKit). For cloud storage, data is stored as [FHIR](https://github.com/StanfordSpezi/SpeziFHIR) elements on [Firebase](https://github.com/StanfordSpezi/SpeziFirebase).
 
+
+#### Visualization:
+Interactive graphs display trends for: heart rate, temperature, oxygen saturation, absolute neutrophil count (ANC). Visuals include trend lines and daily average readings to help users and clinicians better understand health fluctuations.
+
+### II. Notifications & Alerts
+1. **Critical Health Alerts:**  
+   The app sends immediate alerts if:  
+   - **Fever Detected:** Elevated body temperature, especially when ANC is low (e.g., < 500/µL).  
+   - **Increased Resting Heart Rate:** Heart rate exceeds 100 BPM. 
+   
+   Users receive a push notification advising them to seek medical attention.
+
+2. **Lab Results Reminders:**  
+   If no lab results are logged for over a week, the app sends a reminder to encourage regular data updates.
+
+3. **Neutropenia Severity Classification:**  
+   ANC is automatically calculated based on patient-provided lab values, with severity color codes:  
+   - ANC ≥ 500: Normal (Green)
+   - 100 ≤ ANC < 500: Severe Neutropenia (Orange)  
+   - ANC < 100: Profound Neutropenia (Red)
+
+> [!NOTE]  
+> Want to understand how background checking and lab results reminders work? Check out the detailed explanation in [Background Checking & Lab Notification](Notification.md).
+
+
+## Setup Instructions
+Use [TestFlight](https://testflight.apple.com/join/CAuYHs84) to download NeutroFeverGuard. Following the instruction when onboarding: sign the consent form, give permissions to health data and notification, sign up and provide your data. 
+
+Enjoy!
 
 ## Contributing
 


### PR DESCRIPTION
# *Update documentation*

## :recycle: Current situation & Problem
I updated the README to better reflect NeutroFeverGuard’s features, including detailed sections on health tracking, notifications, and lab result reminders. Besides the background checking and lab notification logic are part of our contribution, which previously were not well-documented, making it harder for future developers to understand how event completion and schedule restarts work. 


## :gear: Release Notes 
- **Updated README:**  
  - Added a more detailed app overview.  
  - Included sections on health data tracking, visualization, and notification features.  
  - Added TestFlight download instructions.  

- **Added Background Checking & Lab Notification Documentation:**  
  - Explained how lab notification works as Nick suggests.
  - (Need @mmervecerit to add explanation for background checking)


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
