### PR TITLE
Combine lab results and medications into one page with two tabs, fix bug, revise ui tests

### DIFF
--- a/NeutroFeverGuard.xcodeproj/project.pbxproj
+++ b/NeutroFeverGuard.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		C42C1C6B2D7A985B00EA417F /* MedicationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42C1C6A2D7A985B00EA417F /* MedicationManager.swift */; };
 		C42C1C712D7AB84300EA417F /* MedicationViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42C1C702D7AB84300EA417F /* MedicationViewUITests.swift */; };
 		C42D4DA52D5AC89900B2A169 /* LabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42D4DA42D5AC89500B2A169 /* LabView.swift */; };
+		C48838FA2D7F849E00D25764 /* RecordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48838F92D7F849800D25764 /* RecordsView.swift */; };
 		C49EC8342D501C62005C3495 /* DataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49EC8332D501C5C005C3495 /* DataType.swift */; };
 		C49EC8382D5026EE005C3495 /* DataTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49EC8372D5026EE005C3495 /* DataTypeTest.swift */; };
 		C49EC8402D5033F9005C3495 /* AddDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49EC83F2D5033F9005C3495 /* AddDataView.swift */; };
@@ -160,6 +161,7 @@
 		C42C1C6A2D7A985B00EA417F /* MedicationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationManager.swift; sourceTree = "<group>"; };
 		C42C1C702D7AB84300EA417F /* MedicationViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationViewUITests.swift; sourceTree = "<group>"; };
 		C42D4DA42D5AC89500B2A169 /* LabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabView.swift; sourceTree = "<group>"; };
+		C48838F92D7F849800D25764 /* RecordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordsView.swift; sourceTree = "<group>"; };
 		C49EC8332D501C5C005C3495 /* DataType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataType.swift; sourceTree = "<group>"; };
 		C49EC8372D5026EE005C3495 /* DataTypeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTypeTest.swift; sourceTree = "<group>"; };
 		C49EC83F2D5033F9005C3495 /* AddDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDataView.swift; sourceTree = "<group>"; };
@@ -338,6 +340,7 @@
 				EB7D47E02D51433200CEDC78 /* HealthKitVisualizations */,
 				F22393792D5D4092006C8EB4 /* DataError.swift */,
 				C42D4DA42D5AC89500B2A169 /* LabView.swift */,
+				C48838F92D7F849800D25764 /* RecordsView.swift */,
 				B0C95E382D78D5F2007A4CA6 /* FeverMonitoring.swift */,
 				C42C1B302D782A7100EA417F /* MedicationView.swift */,
 				C4C0A78E2D518DB500F37EEC /* HelperFunc.swift */,
@@ -640,6 +643,7 @@
 				C49EC8402D5033F9005C3495 /* AddDataView.swift in Sources */,
 				C42D4DA52D5AC89900B2A169 /* LabView.swift in Sources */,
 				F2E6898F2D52ED8600869C4F /* HealthKitService.swift in Sources */,
+				C48838FA2D7F849E00D25764 /* RecordsView.swift in Sources */,
 				C49EC8342D501C62005C3495 /* DataType.swift in Sources */,
 				2FE5DC5329EDD7FA004B9AB4 /* Bundle+Questionnaire.swift in Sources */,
 				2F5E32BD297E05EA003432F8 /* NeutroFeverGuardDelegate.swift in Sources */,

--- a/NeutroFeverGuard.xcodeproj/xcshareddata/xcschemes/NeutroFeverGuard.xcscheme
+++ b/NeutroFeverGuard.xcodeproj/xcshareddata/xcschemes/NeutroFeverGuard.xcscheme
@@ -83,7 +83,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--showOnboarding"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--skipOnboarding"

--- a/NeutroFeverGuard/HomeView.swift
+++ b/NeutroFeverGuard/HomeView.swift
@@ -14,8 +14,9 @@ struct HomeView: View {
     enum Tabs: String {
 //        case dashboard
         case addData
-        case labResult
-        case medication
+//        case labResult
+//        case medication
+        case records
 //        case schedule
         case contact
     }
@@ -41,19 +42,12 @@ struct HomeView: View {
             .customizationID("home.addData")
             .accessibilityIdentifier("Add Data")
             
-            // Lab tab
-            Tab("Lab", systemImage: "flask", value: .labResult) {
-                LabView(presentingAccount: $presentingAccount)
+            // Record tab
+            Tab("Records", systemImage: "list.clipboard", value: .records) {
+                RecordsView(presentingAccount: $presentingAccount)
             }
-            .customizationID("home.lab")
-            .accessibilityIdentifier("Lab")
-            
-            // Medication tab
-            Tab("Medication", systemImage: "pills", value: .medication) {
-                MedicationView(presentingAccount: $presentingAccount)
-            }
-            .customizationID("home.medication")
-            .accessibilityIdentifier("Medication")
+            .customizationID("home.records")
+            .accessibilityIdentifier("Records")
             
             // Schedule tab
 //            Tab("Schedule", systemImage: "list.clipboard", value: .schedule) {

--- a/NeutroFeverGuard/LabResultsManager.swift
+++ b/NeutroFeverGuard/LabResultsManager.swift
@@ -57,6 +57,7 @@ class LabResultsManager: Module, EnvironmentAccessible {
             results = []
         }
         
+        results.sort { $0.date > $1.date }
         self.labRecords = results
         if let latestRecord = results.first {
             latestRecordedTime = formatDate(latestRecord.date)

--- a/NeutroFeverGuard/LabView.swift
+++ b/NeutroFeverGuard/LabView.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SpeziAccount
 import SpeziLocalStorage
 import SwiftUI
 
@@ -122,24 +121,19 @@ struct LabResultDetailView: View {
 
 struct LabView: View {
     @Environment(LabResultsManager.self) private var labResultsManager
-    @Environment(Account.self) private var account: Account?
-    @Binding var presentingAccount: Bool
 //    @Environment(NeutroFeverGuardScheduler.self) private var scheduler
 
     var body: some View {
-        NavigationView {
-            List {
-                ancSection()
-                labHistorySection()
-            }
-            .listStyle(.insetGrouped)
-            .navigationTitle("Lab Results")
-            .background(Color(.systemGray6))
-            .toolbar { toolbarContent() }
-            .onAppear {
-                labResultsManager.refresh()
+        List {
+            ancSection()
+            labHistorySection()
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Lab Results")
+        .background(Color(.systemGray6))
+        .onAppear {
+            labResultsManager.refresh()
 //                scheduler.printUpcomingLabResultEvents()
-            }
         }
     }
     
@@ -170,16 +164,8 @@ struct LabView: View {
             }
         }
     }
-
-    private func toolbarContent() -> some ToolbarContent {
-        ToolbarItem {
-            if account != nil {
-                AccountButton(isPresented: $presentingAccount)
-            }
-        }
-    }
 }
 
 #Preview {
-    LabView(presentingAccount: .constant(false))
+    LabView()
 }

--- a/NeutroFeverGuard/MedicationManager.swift
+++ b/NeutroFeverGuard/MedicationManager.swift
@@ -58,8 +58,10 @@ class MedicationManager: Module, EnvironmentAccessible {
         saveMedResults()
     }
     
-    func deleteMedEntry(at offsets: IndexSet) {
-        medications.remove(atOffsets: offsets)
+    func deleteMedEntry(at index: Int) {
+        guard medications.indices.contains(index)
+            else { return }
+        medications.remove(at: index)
         saveMedResults()
     }
 

--- a/NeutroFeverGuard/MedicationView.swift
+++ b/NeutroFeverGuard/MedicationView.swift
@@ -110,47 +110,64 @@ struct MedicationEditForm: View {
 
 struct MedicationView: View {
     @Environment(MedicationManager.self) private var medicationManager
-    @Environment(Account.self) private var account: Account?
     @State private var isEditing = false
     @State private var editingMedicationIndex: Int = 0
-    @Binding var presentingAccount: Bool
+    @State private var deleteMedicationIndex: Int = 0
+    @State private var showDeleteAlert = false
 
     var body: some View {
-        NavigationView {
-            List {
-                if medicationManager.medications.isEmpty {
-                    Text("No medications recorded").foregroundColor(.gray)
-                } else {
-                    ForEach(Array(medicationManager.medications.enumerated()), id: \.element.date) { index, medication in
+        List {
+            if medicationManager.medications.isEmpty {
+                Text("No medications recorded").foregroundColor(.gray)
+            } else {
+                ForEach(Array(medicationManager.medications.enumerated()), id: \.element.date) { index, medication in
+                    HStack {
                         MedicationRow(medication: medication)
-                            .swipeActions(edge: .leading) {
-                                Button("Edit") {
-                                    editingMedicationIndex = index
-                                    isEditing = true
-                                }.tint(.blue)
+                        Spacer()
+                        VStack {
+                            Button("Edit") {
+                                editingMedicationIndex = index
+                                isEditing = true
                             }
+                            .buttonStyle(.plain)
+                            .foregroundColor(.blue)
+                            .padding(.bottom, 4)
+                            
+                            Button("Delete") {
+                                deleteMedicationIndex = index
+                                showDeleteAlert = true
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundColor(.red)
+                        }
                     }
-                    .onDelete { offsets in medicationManager.deleteMedEntry(at: offsets) }
                 }
             }
-            .navigationTitle("Medication List")
-            .onAppear { medicationManager.refresh() }
-            .listStyle(.insetGrouped)
-            .background(Color(.systemGray6))
-            .toolbar { if account != nil { AccountButton(isPresented: $presentingAccount) } }
-            .sheet(isPresented: $isEditing) {
-                let index = editingMedicationIndex
-                MedicationEditForm(
-                    medication: medicationManager.medications[index],
-                    onSave: {updatedMedication in
-                        medicationManager.updateMedEntry(at: index, with: updatedMedication)
-                        isEditing = false
-                    },
-                    onCancel: {
-                        isEditing = false
-                    }
-                )
-            }
+        }
+        .navigationTitle("Medication List")
+        .onAppear { medicationManager.refresh() }
+        .listStyle(.insetGrouped)
+        .background(Color(.systemGray6))
+        .sheet(isPresented: $isEditing) {
+            let index = editingMedicationIndex
+            MedicationEditForm(
+                medication: medicationManager.medications[index],
+                onSave: {updatedMedication in
+                    medicationManager.updateMedEntry(at: index, with: updatedMedication)
+                    isEditing = false
+                },
+                onCancel: {
+                    isEditing = false
+                }
+            )
+        }
+        .alert("Delete Medication", isPresented: $showDeleteAlert) {
+                Button("Delete", role: .destructive) {
+                    medicationManager.deleteMedEntry(at: deleteMedicationIndex)
+                }.accessibilityIdentifier("DeleteAlertButton")
+                Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Are you sure you want to delete this medication record? This action cannot be undone.")
         }
     }
 }

--- a/NeutroFeverGuard/MedicationView.swift
+++ b/NeutroFeverGuard/MedicationView.swift
@@ -164,7 +164,7 @@ struct MedicationView: View {
         .alert("Delete Medication", isPresented: $showDeleteAlert) {
                 Button("Delete", role: .destructive) {
                     medicationManager.deleteMedEntry(at: deleteMedicationIndex)
-                }.accessibilityIdentifier("DeleteAlertButton")
+                }.accessibilityIdentifier("MedDeleteAlertButton")
                 Button("Cancel", role: .cancel) {}
         } message: {
             Text("Are you sure you want to delete this medication record? This action cannot be undone.")

--- a/NeutroFeverGuard/RecordsView.swift
+++ b/NeutroFeverGuard/RecordsView.swift
@@ -1,0 +1,55 @@
+//
+// This source file is part of the NeutroFeverGuard based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziAccount
+import SpeziLocalStorage
+import SwiftUI
+
+enum HealthSection {
+    case labResults
+    case medications
+}
+
+struct RecordsView: View {
+    @Environment(Account.self) private var account: Account?
+    @Binding var presentingAccount: Bool
+    
+    @State private var selectedSection: HealthSection = .labResults
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                Picker("Select Section", selection: $selectedSection) {
+                    Text("Lab Results").tag(HealthSection.labResults)
+                    Text("Medications").tag(HealthSection.medications)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .padding()
+
+                TabView(selection: $selectedSection) {
+                    LabView()
+                        .tag(HealthSection.labResults)
+                    MedicationView()
+                        .tag(HealthSection.medications)
+                }
+                .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+            }
+            .navigationTitle("Health Data")
+            .toolbar { toolbarContent() }
+            .background(Color(.systemGray6))
+        }
+    }
+    
+    private func toolbarContent() -> some ToolbarContent {
+        ToolbarItem {
+            if account != nil {
+                AccountButton(isPresented: $presentingAccount)
+            }
+        }
+    }
+}

--- a/NeutroFeverGuard/Resources/Localizable.xcstrings
+++ b/NeutroFeverGuard/Resources/Localizable.xcstrings
@@ -133,6 +133,9 @@
     "Are you sure you want to delete this lab record? This action cannot be undone." : {
 
     },
+    "Are you sure you want to delete this medication record? This action cannot be undone." : {
+
+    },
     "Body Temperature (°F)" : {
       "localizations" : {
         "en" : {
@@ -223,6 +226,9 @@
     "Delete Lab Record" : {
 
     },
+    "Delete Medication" : {
+
+    },
     "Diastolic (mmHg)" : {
       "localizations" : {
         "en" : {
@@ -277,6 +283,9 @@
           }
         }
       }
+    },
+    "Health Data" : {
+
     },
     "Health Data Access" : {
 
@@ -475,6 +484,7 @@
       }
     },
     "Lab" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -559,13 +569,13 @@
         }
       }
     },
-    "Medication" : {
-
-    },
     "Medication List" : {
 
     },
     "Medication Name" : {
+
+    },
+    "Medications" : {
 
     },
     "Name" : {
@@ -732,6 +742,9 @@
     "Record & Track Symptoms" : {
 
     },
+    "Records" : {
+
+    },
     "Save" : {
 
     },
@@ -745,6 +758,9 @@
           }
         }
       }
+    },
+    "Select Section" : {
+
     },
     "Sign the Consent Form" : {
 

--- a/NeutroFeverGuardUITests/LabViewUITests.swift
+++ b/NeutroFeverGuardUITests/LabViewUITests.swift
@@ -25,8 +25,13 @@ class LabViewTests: XCTestCase {
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
 
-        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Lab"].waitForExistence(timeout: 2))
-        app.tabBars["Tab Bar"].buttons["Lab"].tap()
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Records"].waitForExistence(timeout: 2))
+        app.tabBars["Tab Bar"].buttons["Records"].tap()
+        
+        let segmentedControl = app.segmentedControls.element(boundBy: 0)
+        let labResultsButton = segmentedControl.buttons["Lab Results"]
+        XCTAssertTrue(labResultsButton.waitForExistence(timeout: 2))
+        labResultsButton.tap()
 
         XCTAssertTrue(app.navigationBars["Lab Results"].waitForExistence(timeout: 2))
 
@@ -37,8 +42,9 @@ class LabViewTests: XCTestCase {
         XCTAssertTrue(ancValueExists, "ANC value should be displayed")
 
         XCTAssertTrue(app.staticTexts["LAB RESULTS HISTORY"].exists)
+//        print(app.debugDescription)
 
-        let firstLabResult = app.cells.element(boundBy: 1) // The first cell after the ANC section
+        let firstLabResult = app.cells.element(boundBy: 2) // The first cell after the ANC section
         XCTAssertTrue(firstLabResult.waitForExistence(timeout: 2))
         firstLabResult.tap()
 
@@ -59,10 +65,13 @@ class LabViewTests: XCTestCase {
     func testLabDelete() throws {
         let app = XCUIApplication()
 
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-
-        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Lab"].waitForExistence(timeout: 2))
-        app.tabBars["Tab Bar"].buttons["Lab"].tap()
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Records"].waitForExistence(timeout: 2))
+        app.tabBars["Tab Bar"].buttons["Records"].tap()
+        
+        let segmentedControl = app.segmentedControls.element(boundBy: 0)
+        let labResultsButton = segmentedControl.buttons["Lab Results"]
+        XCTAssertTrue(labResultsButton.waitForExistence(timeout: 2))
+        labResultsButton.tap()
 
         XCTAssertTrue(app.navigationBars["Lab Results"].waitForExistence(timeout: 2))
 
@@ -74,16 +83,12 @@ class LabViewTests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["LAB RESULTS HISTORY"].waitForExistence(timeout: 2))
 
-        let firstLabResult = app.cells.element(boundBy: 1) // The first cell after the ANC section
+        let firstLabResult = app.cells.element(boundBy: 2) // The first cell after the ANC section
         XCTAssertTrue(firstLabResult.waitForExistence(timeout: 2))
         firstLabResult.tap()
-
-        print(app.debugDescription)
         
         XCTAssertTrue(app.buttons["Delete"].waitForExistence(timeout: 2))
         app.buttons["Delete"].tap()
-        
-        print(app.debugDescription)
         
         XCTAssertTrue(app.staticTexts["Delete Lab Record"].waitForExistence(timeout: 2))
         

--- a/NeutroFeverGuardUITests/MedicationViewUITests.swift
+++ b/NeutroFeverGuardUITests/MedicationViewUITests.swift
@@ -23,21 +23,22 @@ class MedicationViewTests: XCTestCase {
     func testMedView() throws {
         let app = XCUIApplication()
 
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-
-        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Medication"].waitForExistence(timeout: 2))
-        app.tabBars["Tab Bar"].buttons["Medication"].tap()
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Records"].waitForExistence(timeout: 2))
+        app.tabBars["Tab Bar"].buttons["Records"].tap()
+        
+        let segmentedControl = app.segmentedControls.element(boundBy: 0)
+        let medicationsButton = segmentedControl.buttons["Medications"]
+        XCTAssertTrue(medicationsButton.waitForExistence(timeout: 2))
+        medicationsButton.tap()
 
         XCTAssertTrue(app.navigationBars["Medication List"].waitForExistence(timeout: 2))
 
-        print(app.debugDescription)
         XCTAssertTrue(app.staticTexts["test"].exists)
         XCTAssertTrue(app.staticTexts["Dose: 1.00 mg"].exists)
 
         let dateExists = app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH[c] 'Date:'")).firstMatch.exists
         XCTAssertTrue(dateExists, "Date label should be displayed")
         
-        app.cells.firstMatch.swipeRight()
         XCTAssertTrue(app.buttons["Edit"].waitForExistence(timeout: 2))
         app.buttons["Edit"].tap()
         
@@ -55,14 +56,20 @@ class MedicationViewTests: XCTestCase {
     func testMedDelete() throws {
         let app = XCUIApplication()
 
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Records"].waitForExistence(timeout: 2))
+        app.tabBars["Tab Bar"].buttons["Records"].tap()
+        
+        let segmentedControl = app.segmentedControls.element(boundBy: 0)
+        let medicationsButton = segmentedControl.buttons["Medications"]
+        XCTAssertTrue(medicationsButton.waitForExistence(timeout: 2))
+        medicationsButton.tap()
 
-        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Medication"].waitForExistence(timeout: 2))
-        app.tabBars["Tab Bar"].buttons["Medication"].tap()
-
-        app.cells.firstMatch.swipeLeft()
         XCTAssertTrue(app.buttons["Delete"].waitForExistence(timeout: 2))
         app.buttons["Delete"].tap()
+        
+        let deleteAlertButton = app.buttons["MedDeleteAlertButton"]
+        XCTAssertTrue(deleteAlertButton.waitForExistence(timeout: 2))
+        deleteAlertButton.tap()
         
         XCTAssertTrue(app.staticTexts["No medications recorded"].waitForExistence(timeout: 2))
     }
@@ -71,13 +78,14 @@ class MedicationViewTests: XCTestCase {
     func testMedEditCancel() throws {
         let app = XCUIApplication()
 
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-
-        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Medication"].waitForExistence(timeout: 2))
-        app.tabBars["Tab Bar"].buttons["Medication"].tap()
-
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Records"].waitForExistence(timeout: 2))
+        app.tabBars["Tab Bar"].buttons["Records"].tap()
         
-        app.cells.firstMatch.swipeRight()
+        let segmentedControl = app.segmentedControls.element(boundBy: 0)
+        let medicationsButton = segmentedControl.buttons["Medications"]
+        XCTAssertTrue(medicationsButton.waitForExistence(timeout: 2))
+        medicationsButton.tap()
+
         XCTAssertTrue(app.buttons["Edit"].waitForExistence(timeout: 2))
         app.buttons["Edit"].tap()
         
@@ -91,13 +99,14 @@ class MedicationViewTests: XCTestCase {
     func testMedEditInvalid() throws {
         let app = XCUIApplication()
 
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-
-        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Medication"].waitForExistence(timeout: 2))
-        app.tabBars["Tab Bar"].buttons["Medication"].tap()
-
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Records"].waitForExistence(timeout: 2))
+        app.tabBars["Tab Bar"].buttons["Records"].tap()
         
-        app.cells.firstMatch.swipeRight()
+        let segmentedControl = app.segmentedControls.element(boundBy: 0)
+        let medicationsButton = segmentedControl.buttons["Medications"]
+        XCTAssertTrue(medicationsButton.waitForExistence(timeout: 2))
+        medicationsButton.tap()
+
         XCTAssertTrue(app.buttons["Edit"].waitForExistence(timeout: 2))
         app.buttons["Edit"].tap()
     }


### PR DESCRIPTION
# *Combine lab results and medications into one page with two tabs, fix bug, revise ui tests*

## :recycle: Current situation & Problem
Currently, lab results and medications are on separate pages. Since we plan to add a dashboard and a connect page, we want to keep the total number of main pages to five. Given the functional similarities between lab results and medications, it makes sense to combine them into a single page with tabs for better organization and navigation.


## :gear: Release Notes 
1. New Records Page:
    - Combined lab results and medications into a single page with two tabs.
    - Users can switch between lab results and medications without navigating to different pages.
2. UI Improvements:
    - Replaced swipe-to-edit/delete actions for medications with direct "Edit" and "Delete" buttons to avoid conflicts with tab gestures.
    - Added icons and spacing to make the new buttons more intuitive and clean.
3. Bug Fixes:
    - Found and Fixed sorting issue in `LabResultsManager` to ensure records are ordered chronologically.
4. Updated UI Tests:
    - Refactored tests for lab results and medication views to reflect the new tabbed interface.
    - Added checks for the presence of the new buttons and verified the tab-switching behavior.
<img width="385" alt="image" src="https://github.com/user-attachments/assets/a77888a9-b0a5-4846-9b1c-883b2abd0eb7" />

## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
